### PR TITLE
feat: add CRUD APIs for suppliers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './config/swagger.js';
 import productRoutes from './routes/productRoutes.js';
 import orderRoutes from './routes/orderRoutes.js';
+import supplierRoutes from './routes/supplierRoutes.js';
 
 const app = express();
 
@@ -15,5 +16,6 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/products', productRoutes);
 app.use('/orders', orderRoutes);
+app.use('/suppliers', supplierRoutes);
 
 export default app;

--- a/src/controllers/supplierController.js
+++ b/src/controllers/supplierController.js
@@ -1,0 +1,73 @@
+import * as supplierService from '../services/supplierService.js';
+
+export const getAllSuppliers = async (req, res) => {
+  try {
+    const suppliers = await supplierService.getAllSuppliers();
+    res.status(200).json(suppliers);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving suppliers', error: error.message });
+  }
+};
+
+export const getSupplier = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const supplier = await supplierService.getSupplierById(id);
+
+    if (!supplier) {
+      return res.status(404).json({ message: 'Supplier not found' });
+    }
+
+    res.status(200).json(supplier);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving supplier', error: error.message });
+  }
+};
+
+export const createSupplier = async (req, res) => {
+  try {
+    const { id, name, contact, email, products } = req.body;
+
+    if (!id) {
+      return res.status(400).json({ message: 'Supplier ID is required' });
+    }
+
+    const newSupplier = { id, name, contact, email, products };
+    await supplierService.createSupplier(newSupplier);
+    res.status(201).json({ message: 'Supplier created successfully' });
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating supplier', error: error.message });
+  }
+};
+
+export const updateSupplier = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const updates = req.body;
+
+    const updatedSupplier = await supplierService.updateSupplier(id, updates);
+
+    if (!updatedSupplier) {
+      return res.status(404).json({ message: 'Supplier not found' });
+    }
+
+    res.status(200).json({ message: 'Supplier updated successfully' });
+  } catch (error) {
+    res.status(500).json({ message: 'Error updating supplier', error: error.message });
+  }
+};
+
+export const deleteSupplier = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const result = await supplierService.deleteSupplier(id);
+
+    if (result === 0) {
+      return res.status(404).json({ message: 'Supplier not found' });
+    }
+
+    res.status(200).json({ message: 'Supplier deleted successfully' });
+  } catch (error) {
+    res.status(500).json({ message: 'Error deleting supplier', error: error.message });
+  }
+};

--- a/src/routes/supplierRoutes.js
+++ b/src/routes/supplierRoutes.js
@@ -1,0 +1,167 @@
+import { Router } from 'express';
+import {
+  getAllSuppliers,
+  getSupplier,
+  createSupplier,
+  updateSupplier,
+  deleteSupplier,
+} from '../controllers/supplierController.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Supplier:
+ *       type: object
+ *       required:
+ *         - id
+ *         - name
+ *       properties:
+ *         id:
+ *           type: integer
+ *           description: The unique identifier for the supplier
+ *         name:
+ *           type: string
+ *           description: The name of the supplier
+ *         contact:
+ *           type: string
+ *           description: The contact person for the supplier
+ *         email:
+ *           type: string
+ *           description: The email address of the supplier
+ *         products:
+ *           type: array
+ *           items:
+ *             type: integer
+ *           description: A list of product IDs supplied by the supplier
+ *       example:
+ *         id: 1
+ *         name: "ElectroSupply"
+ *         contact: "John Doe"
+ *         email: "john.doe@electrosupply.com"
+ *         products: [1, 2, 8]
+ */
+
+/**
+ * @swagger
+ * tags:
+ *   name: Suppliers
+ *   description: The suppliers managing API
+ */
+
+/**
+ * @swagger
+ * /suppliers:
+ *   get:
+ *     summary: Returns the list of all the suppliers
+ *     tags: [Suppliers]
+ *     responses:
+ *       200:
+ *         description: The list of the suppliers
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Supplier'
+ */
+router.get('/', getAllSuppliers);
+
+/**
+ * @swagger
+ * /suppliers/{id}:
+ *   get:
+ *     summary: Get a supplier by ID
+ *     tags: [Suppliers]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The supplier ID
+ *     responses:
+ *       200:
+ *         description: The supplier description by ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Supplier'
+ *       404:
+ *         description: The supplier was not found
+ */
+router.get('/:id', getSupplier);
+
+/**
+ * @swagger
+ * /suppliers:
+ *   post:
+ *     summary: Create a new supplier
+ *     tags: [Suppliers]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Supplier'
+ *     responses:
+ *       201:
+ *         description: The supplier was successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/', createSupplier);
+
+/**
+ * @swagger
+ * /suppliers/{id}:
+ *   put:
+ *     summary: Update a supplier by ID
+ *     tags: [Suppliers]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The supplier ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Supplier'
+ *     responses:
+ *       200:
+ *         description: The supplier was updated
+ *       404:
+ *         description: The supplier was not found
+ *       500:
+ *         description: Some server error
+ */
+router.put('/:id', updateSupplier);
+
+/**
+ * @swagger
+ * /suppliers/{id}:
+ *   delete:
+ *     summary: Delete a supplier by ID
+ *     tags: [Suppliers]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The supplier ID
+ *     responses:
+ *       200:
+ *         description: The supplier was deleted
+ *       404:
+ *         description: The supplier was not found
+ */
+router.delete('/:id', deleteSupplier);
+
+export default router;

--- a/src/services/supplierService.js
+++ b/src/services/supplierService.js
@@ -1,0 +1,41 @@
+import redisClient from '../config/redisClient.js';
+
+const SUPPLIER_KEY_PREFIX = 'supplier:';
+
+export const getSupplierById = async (id) => {
+  const supplier = await redisClient.get(`${SUPPLIER_KEY_PREFIX}${id}`);
+  return supplier ? JSON.parse(supplier) : null;
+};
+
+export const createSupplier = async (supplier) => {
+  await redisClient.set(`${SUPPLIER_KEY_PREFIX}${supplier.id}`, JSON.stringify(supplier));
+};
+
+export const updateSupplier = async (id, updates) => {
+  const key = `${SUPPLIER_KEY_PREFIX}${id}`;
+  const existingSupplier = await redisClient.get(key);
+
+  if (!existingSupplier) {
+    return null;
+  }
+
+  const supplier = JSON.parse(existingSupplier);
+  const updatedSupplier = { ...supplier, ...updates };
+
+  await redisClient.set(key, JSON.stringify(updatedSupplier));
+  return updatedSupplier;
+};
+
+export const deleteSupplier = async (id) => {
+  const result = await redisClient.del(`${SUPPLIER_KEY_PREFIX}${id}`);
+  return result;
+};
+
+export const getAllSuppliers = async () => {
+  const keys = await redisClient.keys(`${SUPPLIER_KEY_PREFIX}*`);
+  if (!keys.length) {
+    return [];
+  }
+  const suppliers = await redisClient.mget(keys);
+  return suppliers.map(supplier => JSON.parse(supplier));
+};


### PR DESCRIPTION
This commit introduces a new set of CRUD APIs for managing suppliers.

The following endpoints have been added:
- GET /suppliers
- GET /suppliers/:id
- POST /suppliers
- PUT /suppliers/:id
- DELETE /suppliers/:id

A new service layer has been added to handle the business logic for suppliers, including storing and retrieving data from the Redis cache using a 'supplier:' key prefix to avoid conflicts with other data.

Swagger documentation has also been added for the new endpoints.