### PR TITLE
feat: Add APIs for customers and sales orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Users can maintain a wishlist of products they are interested in.
 - **Add to Wishlist**: Add a product to the wishlist with `POST /wishlist`.
 - **Remove from Wishlist**: Remove a product with `DELETE /wishlist/{productId}`.
 
+### Customer Management
+The API now includes endpoints for managing customer data.
+- **CRUD Operations**: Full support for creating, reading, updating, and deleting customers.
+- **Secure Access**: All customer-related endpoints are protected and require authentication.
+
+### Sales Order Management
+The API now includes endpoints for managing sales orders.
+- **CRUD Operations**: Full support for creating, reading,updating, and deleting sales orders.
+- **Secure Access**: All sales order endpoints are protected and require authentication.
+
 ## Prerequisites
 
 - Node.js
@@ -171,6 +181,8 @@ You can use the "Authorize" button in the Swagger UI to add your JWT token and t
 #### `src/controllers`
 
 - **`src/controllers/authController.js`**: This file contains the controller functions for user registration and login.
+- **`src/controllers/customerController.js`**: This file contains the controller functions for the `customers` resource. These functions handle the incoming HTTP requests, call the appropriate service functions to interact with the database, and then send the HTTP responses. It includes functions for all the CRUD operations (`getAllCustomers`, `getCustomer`, `createCustomer`, `updateCustomer`, `deleteCustomer`).
+- **`src/controllers/salesOrderController.js`**: This file contains the controller functions for the `salesOrders` resource. These functions handle the incoming HTTP requests, call the appropriate service functions to interact with the database, and then send the HTTP responses. It includes functions for all the CRUD operations (`getAllSalesOrders`, `getSalesOrder`, `createSalesOrder`, `updateSalesOrder`, `deleteSalesOrder`).
 - **`src/controllers/orderController.js`**: This file contains the controller functions for the `orders` resource. These functions handle the incoming HTTP requests, call the appropriate service functions to interact with the database, and then send the HTTP responses. It includes functions for all the CRUD operations (`getAllOrders`, `getOrder`, `createOrder`, `updateOrder`, `deleteOrder`) as well as the enhanced query endpoints (`getOrdersBySupplier`, `getOrdersByStatus`).
 - **`src/controllers/productController.js`**: This file contains the controller functions for the `products` resource. These functions handle the incoming HTTP requests, call the appropriate service functions to interact with the database, and then send the HTTP responses. It includes functions for all the CRUD operations (`getAllProducts`, `getProduct`, `createProduct`, `updateProduct`, `deleteProduct`).
 - **`src/controllers/locationController.js`**: This file contains the controller functions for the `locations` resource. These functions handle the incoming HTTP requests, call the appropriate service functions to interact with the database, and then send the HTTP responses. It includes functions for all the CRUD operations (`getAllLocations`, `getLocation`, `createLocation`, `updateLocation`, `deleteLocation`).
@@ -188,6 +200,8 @@ You can use the "Authorize" button in the Swagger UI to add your JWT token and t
 #### `src/routes`
 
 - **`src/routes/authRoutes.js`**: This file defines the API routes for authentication (`/register`, `/login`).
+- **`src/routes/customerRoutes.js`**: This file defines the API routes for the `customers` resource. It uses an Express Router to create the routes and associates them with the corresponding controller functions from `customerController.js`. This file also contains the Swagger JSDoc annotations that define the `Customer` schema and the API endpoints for the Swagger documentation.
+- **`src/routes/salesOrderRoutes.js`**: This file defines the API routes for the `salesOrders` resource. It uses an Express Router to create the routes and associates them with the corresponding controller functions from `salesOrderController.js`. This file also contains the Swagger JSDoc annotations that define the `SalesOrder` schema and the API endpoints for the Swagger documentation.
 - **`src/routes/orderRoutes.js`**: This file defines the API routes for the `orders` resource. It uses an Express Router to create the routes and associates them with the corresponding controller functions from `orderController.js`. This file also contains the Swagger JSDoc annotations that define the `Order` schema and the API endpoints for the Swagger documentation.
 - **`src/routes/productRoutes.js`**: This file defines the API routes for the `products` resource. It uses an Express Router to create the routes and associates them with the corresponding controller functions from `productController.js`. This file also contains the Swagger JSDoc annotations that define the `Product` schema and the API endpoints for the Swagger documentation.
 - **`src/routes/locationRoutes.js`**: This file defines the API routes for the `locations` resource. It uses an Express Router to create the routes and associates them with the corresponding controller functions from `locationController.js`. This file also contains the Swagger JSDoc annotations that define the `Location` schema and the API endpoints for the Swagger documentation.
@@ -201,6 +215,8 @@ You can use the "Authorize" button in the Swagger UI to add your JWT token and t
 #### `src/services`
 
 - **`src/services/authService.js`**: This service handles the logic for user registration (password hashing) and login (password verification and JWT creation).
+- **`src/services/customerService.js`**: This file contains the service functions for the `customers` resource. These functions encapsulate the business logic and interact with the in-memory data store to perform CRUD operations.
+- **`src/services/salesOrderService.js`**: This file contains the service functions for the `salesOrders` resource. These functions encapsulate the business logic and interact with the in-memory data store to perform CRUD operations.
 - **`src/services/orderService.js`**: This file contains the service functions for the `orders` resource. These functions encapsulate the business logic and interact with the Redis database. **It now includes stock validation before creating an order.** It also uses efficient Redis sets for indexing orders by status and supplier.
 - **`src/services/productService.js`**: This file contains the service functions for the `products` resource. These functions encapsulate the business logic and interact with the Redis database. **It now auto-generates numeric IDs and maintains an index for them.**
 - **`src/services/locationService.js`**: This file contains the service functions for the `locations` resource. These functions encapsulate the business logic and interact with the Redis database to perform CRUD operations. It uses the `redisClient` to store and retrieve location data, which is prefixed with `location:`. It uses a Redis counter to generate auto-incrementing integer IDs for new locations.

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,8 @@ import authRoutes from './routes/authRoutes.js';
 import promotionRoutes from './routes/promotionRoutes.js';
 import auditRoutes from './routes/auditRoutes.js';
 import wishlistRoutes from './routes/wishlistRoutes.js';
+import customerRoutes from './routes/customerRoutes.js';
+import salesOrderRoutes from './routes/salesOrderRoutes.js';
 
 const app = express();
 
@@ -31,5 +33,7 @@ app.use('/auth', authRoutes);
 app.use('/promotions', promotionRoutes);
 app.use('/audit', auditRoutes);
 app.use('/wishlist', wishlistRoutes);
+app.use('/customers', customerRoutes);
+app.use('/sales-orders', salesOrderRoutes);
 
 export default app;

--- a/src/controllers/customerController.js
+++ b/src/controllers/customerController.js
@@ -1,0 +1,67 @@
+import * as customerService from '../services/customerService.js';
+
+export const getAllCustomers = async (req, res) => {
+  try {
+    const customers = await customerService.getAllCustomers();
+    res.status(200).json(customers);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving customers', error: error.message });
+  }
+};
+
+export const getCustomer = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const customer = await customerService.getCustomerById(id);
+
+    if (!customer) {
+      return res.status(404).json({ message: 'Customer not found' });
+    }
+
+    res.status(200).json(customer);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving customer', error: error.message });
+  }
+};
+
+export const createCustomer = async (req, res) => {
+  try {
+    const newCustomer = await customerService.createCustomer(req.body);
+    res.status(201).json(newCustomer);
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating customer', error: error.message });
+  }
+};
+
+export const updateCustomer = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const updates = req.body;
+
+    const updatedCustomer = await customerService.updateCustomer(id, updates);
+
+    if (!updatedCustomer) {
+      return res.status(404).json({ message: 'Customer not found' });
+    }
+
+    res.status(200).json({ message: 'Customer updated successfully' });
+  } catch (error)
+    {
+    res.status(500).json({ message: 'Error updating customer', error: error.message });
+    }
+};
+
+export const deleteCustomer = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const result = await customerService.deleteCustomer(id);
+
+        if (result === 0) {
+            return res.status(404).json({ message: 'Customer not found' });
+        }
+
+        res.status(200).json({ message: 'Customer deleted successfully' });
+    } catch (error) {
+        res.status(500).json({ message: 'Error deleting customer', error: error.message });
+    }
+};

--- a/src/controllers/salesOrderController.js
+++ b/src/controllers/salesOrderController.js
@@ -1,0 +1,66 @@
+import * as salesOrderService from '../services/salesOrderService.js';
+
+export const getAllSalesOrders = async (req, res) => {
+    try {
+        const salesOrders = await salesOrderService.getAllSalesOrders();
+        res.status(200).json(salesOrders);
+    } catch (error) {
+        res.status(500).json({ message: 'Error retrieving sales orders', error: error.message });
+    }
+};
+
+export const getSalesOrder = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const salesOrder = await salesOrderService.getSalesOrderById(id);
+
+        if (!salesOrder) {
+            return res.status(404).json({ message: 'Sales order not found' });
+        }
+
+        res.status(200).json(salesOrder);
+    } catch (error) {
+        res.status(500).json({ message: 'Error retrieving sales order', error: error.message });
+    }
+};
+
+export const createSalesOrder = async (req, res) => {
+    try {
+        const newSalesOrder = await salesOrderService.createSalesOrder(req.body);
+        res.status(201).json(newSalesOrder);
+    } catch (error) {
+        res.status(500).json({ message: 'Error creating sales order', error: error.message });
+    }
+};
+
+export const updateSalesOrder = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const updates = req.body;
+
+        const updatedSalesOrder = await salesOrderService.updateSalesOrder(id, updates);
+
+        if (!updatedSalesOrder) {
+            return res.status(404).json({ message: 'Sales order not found' });
+        }
+
+        res.status(200).json({ message: 'Sales order updated successfully' });
+    } catch (error) {
+        res.status(500).json({ message: 'Error updating sales order', error: error.message });
+    }
+};
+
+export const deleteSalesOrder = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const result = await salesOrderService.deleteSalesOrder(id);
+
+        if (result === 0) {
+            return res.status(404).json({ message: 'Sales order not found' });
+        }
+
+        res.status(200).json({ message: 'Sales order deleted successfully' });
+    } catch (error) {
+        res.status(500).json({ message: 'Error deleting sales order', error: error.message });
+    }
+};

--- a/src/routes/customerRoutes.js
+++ b/src/routes/customerRoutes.js
@@ -1,0 +1,176 @@
+import { Router } from 'express';
+import {
+  getAllCustomers,
+  getCustomer,
+  createCustomer,
+  updateCustomer,
+  deleteCustomer,
+} from '../controllers/customerController.js';
+import { protect } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Customer:
+ *       type: object
+ *       required:
+ *         - name
+ *         - email
+ *       properties:
+ *         id:
+ *           type: number
+ *           description: The numeric ID of the customer
+ *         name:
+ *           type: string
+ *           description: The name of the customer
+ *         email:
+ *           type: string
+ *           description: The email of the customer
+ *         phone:
+ *           type: string
+ *           description: The phone number of the customer
+ *         address:
+ *           type: string
+ *           description: The address of the customer
+ *       example:
+ *         id: 1
+ *         name: "John Smith"
+ *         email: "john.smith@example.com"
+ *         phone: "555-1234"
+ *         address: "123 Main St, Anytown, USA"
+ */
+
+/**
+ * @swagger
+ * tags:
+ *   name: Customers
+ *   description: The customers managing API
+ */
+
+/**
+ * @swagger
+ * /customers:
+ *   get:
+ *     summary: Returns the list of all the customers
+ *     tags: [Customers]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The list of the customers
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Customer'
+ */
+router.get('/', protect, getAllCustomers);
+
+/**
+ * @swagger
+ * /customers/{id}:
+ *   get:
+ *     summary: Get a customer by ID
+ *     tags: [Customers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The customer ID
+ *     responses:
+ *       200:
+ *         description: The customer description by ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Customer'
+ *       404:
+ *         description: The customer was not found
+ */
+router.get('/:id', protect, getCustomer);
+
+/**
+ * @swagger
+ * /customers:
+ *   post:
+ *     summary: Create a new customer
+ *     tags: [Customers]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Customer'
+ *     responses:
+ *       201:
+ *         description: The customer was successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/', protect, createCustomer);
+
+/**
+ * @swagger
+ * /customers/{id}:
+ *   put:
+ *     summary: Update a customer by ID
+ *     tags: [Customers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The customer ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Customer'
+ *     responses:
+ *       200:
+ *         description: The customer was updated
+ *       404:
+ *         description: The customer was not found
+ *       500:
+ *         description: Some server error
+ */
+router.put('/:id', protect, updateCustomer);
+
+/**
+ * @swagger
+ * /customers/{id}:
+ *   delete:
+ *     summary: Delete a customer by ID
+ *     tags: [Customers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The customer ID
+ *     responses:
+ *       200:
+ *         description: The customer was deleted
+ *       404:
+ *         description: The customer was not found
+ */
+router.delete('/:id', protect, deleteCustomer);
+
+export default router;

--- a/src/routes/salesOrderRoutes.js
+++ b/src/routes/salesOrderRoutes.js
@@ -1,0 +1,205 @@
+import { Router } from 'express';
+import {
+  getAllSalesOrders,
+  getSalesOrder,
+  createSalesOrder,
+  updateSalesOrder,
+  deleteSalesOrder,
+} from '../controllers/salesOrderController.js';
+import { protect } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     SalesOrder:
+ *       type: object
+ *       required:
+ *         - customerId
+ *         - customerName
+ *         - items
+ *         - total
+ *       properties:
+ *         id:
+ *           type: number
+ *           description: The numeric ID of the sales order
+ *         customerId:
+ *           type: number
+ *           description: The ID of the customer
+ *         customerName:
+ *           type: string
+ *           description: The name of the customer
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date and time the order was created
+ *         status:
+ *           type: string
+ *           description: The status of the order
+ *         items:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               productId:
+ *                 type: number
+ *               productName:
+ *                 type: string
+ *               quantity:
+ *                 type: number
+ *               price:
+ *                 type: number
+ *         total:
+ *           type: number
+ *           description: The total amount of the order
+ *       example:
+ *         id: 1
+ *         customerId: 1
+ *         customerName: "John Smith"
+ *         createdAt: "2025-08-14T10:00:00Z"
+ *         status: "Completed"
+ *         items:
+ *           - productId: 1
+ *             productName: "Wireless Mouse"
+ *             quantity: 1
+ *             price: 25.99
+ *           - productId: 2
+ *             productName: "Mechanical Keyboard"
+ *             quantity: 1
+ *             price: 120.00
+ *         total: 145.99
+ */
+
+/**
+ * @swagger
+ * tags:
+ *   name: SalesOrders
+ *   description: The sales orders managing API
+ */
+
+/**
+ * @swagger
+ * /sales-orders:
+ *   get:
+ *     summary: Returns the list of all the sales orders
+ *     tags: [SalesOrders]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The list of the sales orders
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/SalesOrder'
+ */
+router.get('/', protect, getAllSalesOrders);
+
+/**
+ * @swagger
+ * /sales-orders/{id}:
+ *   get:
+ *     summary: Get a sales order by ID
+ *     tags: [SalesOrders]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The sales order ID
+ *     responses:
+ *       200:
+ *         description: The sales order description by ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SalesOrder'
+ *       404:
+ *         description: The sales order was not found
+ */
+router.get('/:id', protect, getSalesOrder);
+
+/**
+ * @swagger
+ * /sales-orders:
+ *   post:
+ *     summary: Create a new sales order
+ *     tags: [SalesOrders]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SalesOrder'
+ *     responses:
+ *       201:
+ *         description: The sales order was successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/', protect, createSalesOrder);
+
+/**
+ * @swagger
+ * /sales-orders/{id}:
+ *   put:
+ *     summary: Update a sales order by ID
+ *     tags: [SalesOrders]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The sales order ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SalesOrder'
+ *     responses:
+ *       200:
+ *         description: The sales order was updated
+ *       404:
+ *         description: The sales order was not found
+ *       500:
+ *         description: Some server error
+ */
+router.put('/:id', protect, updateSalesOrder);
+
+/**
+ * @swagger
+ * /sales-orders/{id}:
+ *   delete:
+ *     summary: Delete a sales order by ID
+ *     tags: [SalesOrders]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The sales order ID
+ *     responses:
+ *       200:
+ *         description: The sales order was deleted
+ *       404:
+ *         description: The sales order was not found
+ */
+router.delete('/:id', protect, deleteSalesOrder);
+
+export default router;

--- a/src/services/customerService.js
+++ b/src/services/customerService.js
@@ -1,0 +1,36 @@
+let customers = [
+    { "id": 1, "name": "John Smith", "email": "john.smith@example.com", "phone": "555-1234", "address": "123 Main St, Anytown, USA" },
+    { "id": 2, "name": "Jane Doe", "email": "jane.doe@example.com", "phone": "555-5678", "address": "456 Oak Ave, Othertown, USA" }
+  ];
+
+export const getAllCustomers = async () => {
+    return customers;
+    }
+
+export const getCustomerById = async (id) => {
+    return customers.find(customer => customer.id === parseInt(id));
+    }
+
+export const createCustomer = async (customer) => {
+    const newCustomer = { id: customers.length + 1, ...customer };
+    customers.push(newCustomer);
+    return newCustomer;
+    }
+
+export const updateCustomer = async (id, customer) => {
+    const index = customers.findIndex(c => c.id === parseInt(id));
+    if (index === -1) {
+        return null;
+    }
+    customers[index] = { ...customers[index], ...customer };
+    return customers[index];
+    }
+
+export const deleteCustomer = async (id) => {
+    const index = customers.findIndex(c => c.id === parseInt(id));
+    if (index === -1) {
+        return 0;
+    }
+    customers.splice(index, 1);
+    return 1;
+    }

--- a/src/services/salesOrderService.js
+++ b/src/services/salesOrderService.js
@@ -1,0 +1,57 @@
+let salesOrders = [
+    {
+      "id": 1,
+      "customerId": 1,
+      "customerName": "John Smith",
+      "createdAt": "2025-08-14T10:00:00Z",
+      "status": "Completed",
+      "items": [
+        { "productId": 1, "productName": "Wireless Mouse", "quantity": 1, "price": 25.99 },
+        { "productId": 2, "productName": "Mechanical Keyboard", "quantity": 1, "price": 120.00 }
+      ],
+      "total": 145.99
+    },
+    {
+      "id": 2,
+      "customerId": 2,
+      "customerName": "Jane Doe",
+      "createdAt": "2025-08-15T11:30:00Z",
+      "status": "Pending",
+      "items": [
+        { "productId": 3, "productName": "USB-C Hub", "quantity": 2, "price": 45.50 }
+      ],
+      "total": 91.00
+    }
+  ];
+
+export const getAllSalesOrders = async () => {
+    return salesOrders;
+    }
+
+export const getSalesOrderById = async (id) => {
+    return salesOrders.find(order => order.id === parseInt(id));
+    }
+
+export const createSalesOrder = async (order) => {
+    const newOrder = { id: salesOrders.length + 1, ...order };
+    salesOrders.push(newOrder);
+    return newOrder;
+    }
+
+export const updateSalesOrder = async (id, order) => {
+    const index = salesOrders.findIndex(o => o.id === parseInt(id));
+    if (index === -1) {
+        return null;
+    }
+    salesOrders[index] = { ...salesOrders[index], ...order };
+    return salesOrders[index];
+    }
+
+export const deleteSalesOrder = async (id) => {
+    const index = salesOrders.findIndex(o => o.id === parseInt(id));
+    if (index === -1) {
+        return 0;
+    }
+    salesOrders.splice(index, 1);
+    return 1;
+    }


### PR DESCRIPTION
This change introduces new APIs for managing customers and sales orders, complete with CRUD functionality.

The new APIs are:
- `GET /customers`: Get all customers
- `GET /customers/:id`: Get a customer by ID
- `POST /customers`: Create a new customer
- `PUT /customers/:id`: Update a customer
- `DELETE /customers/:id`: Delete a customer
- `GET /sales-orders`: Get all sales orders
- `GET /sales-orders/:id`: Get a sales order by ID
- `POST /sales-orders`: Create a new sales order
- `PUT /sales-orders/:id`: Update a sales order
- `DELETE /sales-orders/:id`: Delete a sales order

All new endpoints are protected and require authentication.

The `README.md` file has been updated to reflect these changes.