### PR TITLE
fix: Load environment variables in start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/server.js",
   "type": "module",
   "scripts": {
-    "start": "node src/server.js",
+    "start": "node -r dotenv/config src/server.js",
     "test": "node -r dotenv/config --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "jest": {


### PR DESCRIPTION
This commit fixes a bug where the `.env` file was not being loaded when the application was started with `npm start`. This caused the `JWT_SECRET` to be undefined, which resulted in a `500 Internal Server Error` during login.

The `start` script in `package.json` has been updated to include `-r dotenv/config`, which ensures that the `.env` file is loaded correctly.