### PR TITLE
feat: Add role to user registration

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -2,11 +2,11 @@ import * as authService from '../services/authService.js';
 
 export const register = async (req, res) => {
   try {
-    const { name, email, password } = req.body;
+    const { name, email, password, role } = req.body;
     if (!name || !email || !password) {
       return res.status(400).json({ message: 'Name, email, and password are required' });
     }
-    const user = await authService.register({ name, email, password });
+    const user = await authService.register({ name, email, password, role });
     res.status(201).json({ message: 'User registered successfully', userId: user.id });
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -33,6 +33,8 @@ const router = Router();
  *                 type: string
  *               password:
  *                 type: string
+ *               role:
+ *                 type: string
  *     responses:
  *       201:
  *         description: User registered successfully

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken';
 import * as userService from './userService.js';
 
 export const register = async (userData) => {
-  const { name, email, password } = userData;
+  const { name, email, password, role } = userData;
 
   // Check if user already exists
   const existingUser = await userService.getUserByEmail(email);
@@ -20,6 +20,7 @@ export const register = async (userData) => {
     name,
     email,
     password: hashedPassword,
+    role,
   });
 
   return newUser;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -19,7 +19,7 @@ export const getUserById = async (id) => {
 
 export const createUser = async (userData) => {
     const newId = await redisClient.incr('user:id_counter');
-    const newUser = { ...userData, id: newId, role: 'user' };
+    const newUser = { ...userData, id: newId, role: userData.role || 'user' };
 
     const pipeline = redisClient.pipeline();
     pipeline.set(`${USER_KEY_PREFIX}${newUser.id}`, JSON.stringify(newUser));


### PR DESCRIPTION
This commit updates the user registration API (`/auth/register`) to accept a `role` parameter in the request body.

The changes include:
- Updating the Swagger documentation in `src/routes/authRoutes.js` to include the `role` field.
- Modifying the `register` function in `src/controllers/authController.js` to extract the `role` from the request body.
- Updating the `register` function in `src/services/authService.js` to pass the `role` to the user creation service.
- Modifying the `createUser` function in `src/services/userService.js` to use the provided `role` or default to 'user'.