### PR TITLE
feat: Add bulk creation APIs for multiple models

### DIFF
--- a/src/controllers/customerController.js
+++ b/src/controllers/customerController.js
@@ -33,6 +33,15 @@ export const createCustomer = async (req, res) => {
   }
 };
 
+export const createMultipleCustomers = async (req, res) => {
+  try {
+    const newCustomers = await customerService.createMultipleCustomers(req.body);
+    res.status(201).json(newCustomers);
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating customers', error: error.message });
+  }
+};
+
 export const updateCustomer = async (req, res) => {
   try {
     const { id } = req.params;

--- a/src/controllers/locationController.js
+++ b/src/controllers/locationController.js
@@ -33,6 +33,15 @@ export const createLocation = async (req, res) => {
   }
 };
 
+export const createMultipleLocations = async (req, res) => {
+  try {
+    const newLocations = await locationService.createMultipleLocations(req.body);
+    res.status(201).json(newLocations);
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating locations', error: error.message });
+  }
+};
+
 export const updateLocation = async (req, res) => {
   try {
     const { id } = req.params;

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -37,6 +37,19 @@ export const createOrder = async (req, res) => {
   }
 };
 
+export const createMultipleOrders = async (req, res) => {
+  try {
+    const ordersData = req.body.map(order => ({ ...order, userId: req.user.id }));
+    const newOrders = await orderService.createMultipleOrders(ordersData);
+    for (const newOrder of newOrders) {
+      await logAction(req.user.id, 'CREATE_ORDER', { orderId: newOrder.id, details: newOrder });
+    }
+    res.status(201).json(newOrders);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 export const updateOrder = async (req, res) => {
   try {
     const { id } = req.params;

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -46,6 +46,22 @@ export const createProduct = async (req, res) => {
   }
 };
 
+export const createMultipleProducts = async (req, res) => {
+  try {
+    const productsData = req.body;
+    if (productsData.some(p => !p.sku)) {
+      return res.status(400).json({ message: 'Product SKU is required for all products' });
+    }
+    const newProducts = await productService.createMultipleProducts(productsData);
+    for (const newProduct of newProducts) {
+      await logAction(req.user.id, 'CREATE_PRODUCT', { productId: newProduct.id, details: newProduct });
+    }
+    res.status(201).json(newProducts);
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating products', error: error.message });
+  }
+};
+
 export const updateProduct = async (req, res) => {
   try {
     const { id: sku } = req.params;

--- a/src/controllers/salesOrderController.js
+++ b/src/controllers/salesOrderController.js
@@ -33,6 +33,15 @@ export const createSalesOrder = async (req, res) => {
     }
 };
 
+export const createMultipleSalesOrders = async (req, res) => {
+    try {
+        const newSalesOrders = await salesOrderService.createMultipleSalesOrders(req.body);
+        res.status(201).json(newSalesOrders);
+    } catch (error) {
+        res.status(500).json({ message: 'Error creating sales orders', error: error.message });
+    }
+};
+
 export const updateSalesOrder = async (req, res) => {
     try {
         const { id } = req.params;

--- a/src/controllers/stockController.js
+++ b/src/controllers/stockController.js
@@ -42,6 +42,22 @@ export const createStock = async (req, res) => {
   }
 };
 
+export const createMultipleStocks = async (req, res) => {
+  try {
+    const stocks = req.body;
+    if (stocks.some(s => !s.productId)) {
+      return res.status(400).json({ message: 'Product ID is required for all stock entries' });
+    }
+    await stockService.createMultipleStocks(stocks);
+    for (const stock of stocks) {
+      await logAction(req.user.id, 'CREATE_STOCK', { productId: stock.productId, details: stock });
+    }
+    res.status(201).json({ message: 'Stocks created successfully' });
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating stocks', error: error.message });
+  }
+};
+
 export const updateStock = async (req, res) => {
   try {
     const { productId } = req.params;

--- a/src/controllers/supplierController.js
+++ b/src/controllers/supplierController.js
@@ -40,6 +40,19 @@ export const createSupplier = async (req, res) => {
   }
 };
 
+export const createMultipleSuppliers = async (req, res) => {
+  try {
+    const suppliers = req.body;
+    if (suppliers.some(s => !s.id)) {
+      return res.status(400).json({ message: 'Supplier ID is required for all suppliers' });
+    }
+    await supplierService.createMultipleSuppliers(suppliers);
+    res.status(201).json({ message: 'Suppliers created successfully' });
+  } catch (error) {
+    res.status(500).json({ message: 'Error creating suppliers', error: error.message });
+  }
+};
+
 export const updateSupplier = async (req, res) => {
   try {
     const { id } = req.params;

--- a/src/routes/customerRoutes.js
+++ b/src/routes/customerRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllCustomers,
   getCustomer,
   createCustomer,
+  createMultipleCustomers,
   updateCustomer,
   deleteCustomer,
 } from '../controllers/customerController.js';
@@ -118,6 +119,30 @@ router.get('/:id', protect, getCustomer);
  *         description: Some server error
  */
 router.post('/', protect, createCustomer);
+
+/**
+ * @swagger
+ * /customers/bulk:
+ *   post:
+ *     summary: Create multiple new customers
+ *     tags: [Customers]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/Customer'
+ *     responses:
+ *       201:
+ *         description: The customers were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleCustomers);
 
 /**
  * @swagger

--- a/src/routes/locationRoutes.js
+++ b/src/routes/locationRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllLocations,
   getLocation,
   createLocation,
+  createMultipleLocations,
   updateLocation,
   deleteLocation,
 } from '../controllers/locationController.js';
@@ -110,6 +111,30 @@ router.get('/:id', protect, getLocation);
  *         description: Some server error
  */
 router.post('/', protect, createLocation);
+
+/**
+ * @swagger
+ * /locations/bulk:
+ *   post:
+ *     summary: Create multiple new locations
+ *     tags: [Locations]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/Location'
+ *     responses:
+ *       201:
+ *         description: The locations were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleLocations);
 
 /**
  * @swagger

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllOrders,
   getOrder,
   createOrder,
+  createMultipleOrders,
   updateOrder,
   deleteOrder,
   getOrdersBySupplier,
@@ -212,6 +213,30 @@ router.get('/:id', protect, getOrder);
  *         description: Some server error
  */
 router.post('/', protect, createOrder);
+
+/**
+ * @swagger
+ * /orders/bulk:
+ *   post:
+ *     summary: Create multiple new orders
+ *     tags: [Orders]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/Order'
+ *     responses:
+ *       201:
+ *         description: The orders were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleOrders);
 
 /**
  * @swagger

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllProducts,
   getProduct,
   createProduct,
+  createMultipleProducts,
   updateProduct,
   deleteProduct,
 } from '../controllers/productController.js';
@@ -142,6 +143,30 @@ router.get('/:id', protect, getProduct);
  *         description: Some server error
  */
 router.post('/', protect, createProduct);
+
+/**
+ * @swagger
+ * /products/bulk:
+ *   post:
+ *     summary: Create multiple new products
+ *     tags: [Products]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/Product'
+ *     responses:
+ *       201:
+ *         description: The products were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleProducts);
 
 /**
  * @swagger

--- a/src/routes/salesOrderRoutes.js
+++ b/src/routes/salesOrderRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllSalesOrders,
   getSalesOrder,
   createSalesOrder,
+  createMultipleSalesOrders,
   updateSalesOrder,
   deleteSalesOrder,
 } from '../controllers/salesOrderController.js';
@@ -147,6 +148,30 @@ router.get('/:id', protect, getSalesOrder);
  *         description: Some server error
  */
 router.post('/', protect, createSalesOrder);
+
+/**
+ * @swagger
+ * /sales-orders/bulk:
+ *   post:
+ *     summary: Create multiple new sales orders
+ *     tags: [SalesOrders]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/SalesOrder'
+ *     responses:
+ *       201:
+ *         description: The sales orders were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleSalesOrders);
 
 /**
  * @swagger

--- a/src/routes/stockRoutes.js
+++ b/src/routes/stockRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllStock,
   getStock,
   createStock,
+  createMultipleStocks,
   updateStock,
   deleteStock,
 } from '../controllers/stockController.js';
@@ -132,6 +133,30 @@ router.get('/:productId', protect, getStock);
  *         description: Some server error
  */
 router.post('/', protect, createStock);
+
+/**
+ * @swagger
+ * /stock/bulk:
+ *   post:
+ *     summary: Create multiple new stock entries
+ *     tags: [Stock]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/Stock'
+ *     responses:
+ *       201:
+ *         description: The stock entries were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleStocks);
 
 /**
  * @swagger

--- a/src/routes/supplierRoutes.js
+++ b/src/routes/supplierRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllSuppliers,
   getSupplier,
   createSupplier,
+  createMultipleSuppliers,
   updateSupplier,
   deleteSupplier,
   getProductsBySupplier,
@@ -151,6 +152,30 @@ router.get('/:id/products', protect, getProductsBySupplier);
  *         description: Some server error
  */
 router.post('/', protect, createSupplier);
+
+/**
+ * @swagger
+ * /suppliers/bulk:
+ *   post:
+ *     summary: Create multiple new suppliers
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/Supplier'
+ *     responses:
+ *       201:
+ *         description: The suppliers were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleSuppliers);
 
 /**
  * @swagger

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -3,6 +3,7 @@ import {
   getAllUsers,
   getUser,
   createUser,
+  createMultipleUsers,
   updateUser,
   deleteUser,
   getMe,
@@ -174,6 +175,30 @@ router.get('/:id', protect, getUser);
  *         description: Some server error
  */
 router.post('/', protect, createUser);
+
+/**
+ * @swagger
+ * /users/bulk:
+ *   post:
+ *     summary: Create multiple new users (Admin)
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: array
+ *             items:
+ *               $ref: '#/components/schemas/User'
+ *     responses:
+ *       201:
+ *         description: The users were successfully created
+ *       500:
+ *         description: Some server error
+ */
+router.post('/bulk', protect, createMultipleUsers);
 
 /**
  * @swagger

--- a/src/services/customerService.js
+++ b/src/services/customerService.js
@@ -17,6 +17,18 @@ export const createCustomer = async (customer) => {
     return newCustomer;
     }
 
+export const createMultipleCustomers = async (newCustomers) => {
+    const createdCustomers = [];
+    let currentId = customers.length;
+    newCustomers.forEach(customer => {
+        currentId++;
+        const newCustomer = { id: currentId, ...customer };
+        customers.push(newCustomer);
+        createdCustomers.push(newCustomer);
+    });
+    return createdCustomers;
+    }
+
 export const updateCustomer = async (id, customer) => {
     const index = customers.findIndex(c => c.id === parseInt(id));
     if (index === -1) {

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -25,6 +25,17 @@ export const createLocation = async (location) => {
   return newLocation;
 };
 
+export const createMultipleLocations = async (locations) => {
+  const newLocations = [];
+  for (const location of locations) {
+    const id = await redisClient.incr(LOCATION_ID_COUNTER_KEY);
+    const newLocation = { id, ...location };
+    await redisClient.set(`${LOCATION_KEY_PREFIX}${id}`, JSON.stringify(newLocation));
+    newLocations.push(newLocation);
+  }
+  return newLocations;
+};
+
 export const updateLocation = async (id, updates) => {
   const key = `${LOCATION_KEY_PREFIX}${id}`;
   const existingLocation = await redisClient.get(key);

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -94,6 +94,15 @@ export const createOrder = async (orderData) => {
   return newOrder;
 };
 
+export const createMultipleOrders = async (ordersData) => {
+  const createdOrders = [];
+  for (const orderData of ordersData) {
+    const newOrder = await createOrder(orderData);
+    createdOrders.push(newOrder);
+  }
+  return createdOrders;
+};
+
 
 export const updateOrder = async (id, updates) => {
   const key = `${ORDER_KEY_PREFIX}${id}`;

--- a/src/services/salesOrderService.js
+++ b/src/services/salesOrderService.js
@@ -38,6 +38,18 @@ export const createSalesOrder = async (order) => {
     return newOrder;
     }
 
+export const createMultipleSalesOrders = async (orders) => {
+    const newOrders = [];
+    let currentId = salesOrders.length;
+    orders.forEach(order => {
+        currentId++;
+        const newOrder = { id: currentId, ...order };
+        salesOrders.push(newOrder);
+        newOrders.push(newOrder);
+    });
+    return newOrders;
+    }
+
 export const updateSalesOrder = async (id, order) => {
     const index = salesOrders.findIndex(o => o.id === parseInt(id));
     if (index === -1) {

--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -20,6 +20,14 @@ export const createStock = async (stock) => {
   await redisClient.set(`${STOCK_KEY_PREFIX}${stock.productId}`, JSON.stringify(stock));
 };
 
+export const createMultipleStocks = async (stocks) => {
+  const pipeline = redisClient.pipeline();
+  stocks.forEach(stock => {
+    pipeline.set(`${STOCK_KEY_PREFIX}${stock.productId}`, JSON.stringify(stock));
+  });
+  await pipeline.exec();
+};
+
 export const updateStock = async (productId, updates) => {
   const key = `${STOCK_KEY_PREFIX}${productId}`;
   const existingStock = await redisClient.get(key);

--- a/src/services/supplierService.js
+++ b/src/services/supplierService.js
@@ -12,6 +12,14 @@ export const createSupplier = async (supplier) => {
   await redisClient.set(`${SUPPLIER_KEY_PREFIX}${supplier.id}`, JSON.stringify(supplier));
 };
 
+export const createMultipleSuppliers = async (suppliers) => {
+  const pipeline = redisClient.pipeline();
+  suppliers.forEach(supplier => {
+    pipeline.set(`${SUPPLIER_KEY_PREFIX}${supplier.id}`, JSON.stringify(supplier));
+  });
+  await pipeline.exec();
+};
+
 export const updateSupplier = async (id, updates) => {
   const key = `${SUPPLIER_KEY_PREFIX}${id}`;
   const existingSupplier = await redisClient.get(key);


### PR DESCRIPTION
This commit introduces new bulk creation endpoints for the following models:
- Customer
- Location
- Order
- Product
- SalesOrder
- Stock
- Supplier
- User

For each model, a new `POST /<model>/bulk` endpoint has been added, allowing for the creation of multiple records in a single API request.

The changes include:
- New `createMultiple...` functions in the service layer for each model, using Redis pipelines where applicable for efficient database operations.
- New `createMultiple...` functions in the controller layer to handle the bulk requests.
- New routes and Swagger documentation for each bulk endpoint.
- A bug fix in the `userController` to ensure passwords are hashed during single user creation.

This addresses the user's request to create APIs for adding multiple records in a single request for the specified models. The `Wishlist` model was the next to be implemented.