### PR TITLE
Refactor sales order storage to use Redis hashes

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,80 +1,142 @@
-[2025-08-19T15:16:05.005Z] Request: GET /products
+[2025-08-19T15:38:44.233Z] Request: GET /products
   Query: {}
   Body: undefined
   Token: INVALID - jwt malformed
-[2025-08-19T15:16:05.693Z] Request: POST /auth/register
+[2025-08-19T15:38:45.184Z] Request: POST /customers
   Query: {}
-  Body: {"name":"Product Test Admin","email":"product-test-admin@example.com","password":"password123","role":"admin"}
+  Body: {"name":"Test Customer","email":"customer@test.com","phone":"123-456-7890"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.200Z] Request: POST /customers
+  Query: {}
+  Body: {"name":"Test Customer for GET","email":"customerget@test.com"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.207Z] Request: GET /customers/363b1977-251a-4ede-9bae-0ff119ba9762
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.217Z] Request: POST /customers
+  Query: {}
+  Body: {"name":"Test Customer to Update","email":"customerupdate@test.com"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.224Z] Request: PUT /customers/1adb67d0-5cab-47e5-a108-84e96834f036
+  Query: {}
+  Body: {"name":"Updated Customer Name","phone":"987-654-3210"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.232Z] Request: GET /customers/1adb67d0-5cab-47e5-a108-84e96834f036
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.241Z] Request: POST /customers
+  Query: {}
+  Body: {"name":"Test Customer to Delete","email":"customerdelete@test.com"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.248Z] Request: DELETE /customers/6d937b25-b3f8-40c4-aa31-af49faf519b1
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.257Z] Request: GET /customers/6d937b25-b3f8-40c4-aa31-af49faf519b1
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.267Z] Request: POST /customers
+  Query: {}
+  Body: {"name":"Customer A","email":"a@test.com"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.273Z] Request: POST /customers
+  Query: {}
+  Body: {"name":"Customer B","email":"b@test.com"}
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.279Z] Request: GET /customers
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"ece65f5b-f99a-470e-a608-9f8a0f947dc9","name":"Customer Test Admin","email":"customer-test-admin@example.com","role":"admin","iat":1755617925,"exp":1755621525}
+[2025-08-19T15:38:45.930Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Product Test Admin","email":"product-test-admin@example.com","password":"password123","role":"Admin"}
   Token: NOT PROVIDED
-[2025-08-19T15:16:05.830Z] Request: POST /auth/login
+[2025-08-19T15:38:46.062Z] Request: POST /auth/login
   Query: {}
   Body: {"email":"product-test-admin@example.com","password":"password123"}
   Token: NOT PROVIDED
-[2025-08-19T15:16:05.948Z] Request: POST /products
+[2025-08-19T15:38:46.177Z] Request: POST /products
   Query: {}
   Body: {"name":"Test Wireless Mouse","category":"Electronics","price":29.99,"costPrice":18.5,"lowStockThreshold":15,"barcode":"9876543210123"}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:05.960Z] Request: POST /products
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.191Z] Request: POST /products
   Query: {}
   Body: {"name":"Test Mouse for GET","category":"Electronics","price":35.99}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:05.966Z] Request: GET /products/bbb396ed-c257-44b7-afa5-71743b7bf48e
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.197Z] Request: GET /products/68da2a36-70be-4c4a-a3ab-26568a510ba1
   Query: {}
   Body: undefined
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:05.974Z] Request: POST /products
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.206Z] Request: POST /products
   Query: {}
   Body: {"name":"Test Mouse to Update","category":"Peripherals","price":40}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:05.981Z] Request: PUT /products/7814e407-bcc8-429b-9161-106e24b90c73
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.213Z] Request: PUT /products/d4f3af38-290a-43f0-b352-3217e49702f6
   Query: {}
   Body: {"price":38.5,"lowStockThreshold":12}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:05.988Z] Request: GET /products/7814e407-bcc8-429b-9161-106e24b90c73
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.220Z] Request: GET /products/d4f3af38-290a-43f0-b352-3217e49702f6
   Query: {}
   Body: undefined
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:05.997Z] Request: POST /products
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.228Z] Request: POST /products
   Query: {}
   Body: {"name":"Test Mouse to Delete","category":"Disposable","price":5}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:06.004Z] Request: DELETE /products/c1cda391-e083-46a6-8c82-c1e961019c66
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.235Z] Request: DELETE /products/1828c463-397b-4978-b00f-86174a1f774f
   Query: {}
   Body: undefined
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:06.011Z] Request: GET /products/c1cda391-e083-46a6-8c82-c1e961019c66
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.237Z] Deleting product 1828c463-397b-4978-b00f-86174a1f774f for user 162c43c4-cf52-4f39-80e9-f5832d4fc776 from key s:user:162c43c4-cf52-4f39-80e9-f5832d4fc776:products
+[2025-08-19T15:38:46.239Z] Delete result: 1
+[2025-08-19T15:38:46.244Z] Request: GET /products/1828c463-397b-4978-b00f-86174a1f774f
   Query: {}
   Body: undefined
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:06.018Z] Request: POST /products
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.251Z] Request: POST /products
   Query: {}
   Body: {"name":"Product A"}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:06.024Z] Request: POST /products
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.258Z] Request: POST /products
   Query: {}
   Body: {"name":"Product B"}
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:06.030Z] Request: GET /products
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.263Z] Request: GET /products
   Query: {}
   Body: undefined
   Token: VALID
-  User: {"id":"8f2125c3-716c-4853-bbdb-d4fee7aac701","name":"Product Test Admin","email":"product-test-admin@example.com","role":"admin","iat":1755616565,"exp":1755620165}
-[2025-08-19T15:16:06.746Z] Request: GET /products/error
+  User: {"id":"162c43c4-cf52-4f39-80e9-f5832d4fc776","name":"Product Test Admin","email":"product-test-admin@example.com","role":"Admin","iat":1755617926,"exp":1755621526}
+[2025-08-19T15:38:46.926Z] Request: GET /products/error
   Query: {}
   Body: undefined
   Token: NOT PROVIDED
-[2025-08-19T15:16:06.752Z] [ERROR] Error occurred during request: GET /products/error
+[2025-08-19T15:38:46.931Z] [ERROR] Error occurred during request: GET /products/error
   Query: {}
   Body: undefined
   Error: This is a test error.

--- a/src/controllers/salesOrderController.js
+++ b/src/controllers/salesOrderController.js
@@ -2,7 +2,7 @@ import * as salesOrderService from '../services/salesOrderService.js';
 
 export const getAllSalesOrders = async (req, res) => {
     try {
-        const salesOrders = await salesOrderService.getAllSalesOrders();
+        const salesOrders = await salesOrderService.getAllSalesOrders(req.user.id);
         res.status(200).json(salesOrders);
     } catch (error) {
         res.status(500).json({ message: 'Error retrieving sales orders', error: error.message });
@@ -12,7 +12,7 @@ export const getAllSalesOrders = async (req, res) => {
 export const getSalesOrder = async (req, res) => {
     try {
         const { id } = req.params;
-        const salesOrder = await salesOrderService.getSalesOrderById(id);
+        const salesOrder = await salesOrderService.getSalesOrderById(req.user.id, id);
 
         if (!salesOrder) {
             return res.status(404).json({ message: 'Sales order not found' });
@@ -26,7 +26,7 @@ export const getSalesOrder = async (req, res) => {
 
 export const createSalesOrder = async (req, res) => {
     try {
-        const newSalesOrder = await salesOrderService.createSalesOrder(req.body);
+        const newSalesOrder = await salesOrderService.createSalesOrder(req.user.id, req.body);
         res.status(201).json(newSalesOrder);
     } catch (error) {
         res.status(500).json({ message: 'Error creating sales order', error: error.message });
@@ -35,7 +35,7 @@ export const createSalesOrder = async (req, res) => {
 
 export const createMultipleSalesOrders = async (req, res) => {
     try {
-        const newSalesOrders = await salesOrderService.createMultipleSalesOrders(req.body);
+        const newSalesOrders = await salesOrderService.createMultipleSalesOrders(req.user.id, req.body);
         res.status(201).json(newSalesOrders);
     } catch (error) {
         res.status(500).json({ message: 'Error creating sales orders', error: error.message });
@@ -47,13 +47,13 @@ export const updateSalesOrder = async (req, res) => {
         const { id } = req.params;
         const updates = req.body;
 
-        const updatedSalesOrder = await salesOrderService.updateSalesOrder(id, updates);
+        const updatedSalesOrder = await salesOrderService.updateSalesOrder(req.user.id, id, updates);
 
         if (!updatedSalesOrder) {
             return res.status(404).json({ message: 'Sales order not found' });
         }
 
-        res.status(200).json({ message: 'Sales order updated successfully' });
+        res.status(200).json(updatedSalesOrder);
     } catch (error) {
         res.status(500).json({ message: 'Error updating sales order', error: error.message });
     }
@@ -62,7 +62,7 @@ export const updateSalesOrder = async (req, res) => {
 export const deleteSalesOrder = async (req, res) => {
     try {
         const { id } = req.params;
-        const result = await salesOrderService.deleteSalesOrder(id);
+        const result = await salesOrderService.deleteSalesOrder(req.user.id, id);
 
         if (result === 0) {
             return res.status(404).json({ message: 'Sales order not found' });

--- a/src/routes/salesOrderRoutes.js
+++ b/src/routes/salesOrderRoutes.js
@@ -24,8 +24,8 @@ const router = Router();
  *         - total
  *       properties:
  *         id:
- *           type: number
- *           description: The numeric ID of the sales order
+ *           type: string
+ *           description: The UUID of the sales order
  *         customerId:
  *           type: number
  *           description: The ID of the customer
@@ -56,7 +56,7 @@ const router = Router();
  *           type: number
  *           description: The total amount of the order
  *       example:
- *         id: 1
+ *         id: "d290f1ee-6c54-4b01-90e6-d701748f0851"
  *         customerId: 1
  *         customerName: "John Smith"
  *         createdAt: "2025-08-14T10:00:00Z"
@@ -84,7 +84,7 @@ const router = Router();
  * @swagger
  * /salesOrders:
  *   get:
- *     summary: Returns the list of all the sales orders
+ *     summary: Returns the list of all the sales orders for the current user
  *     tags: [SalesOrders]
  *     security:
  *       - bearerAuth: []
@@ -112,9 +112,9 @@ router.get('/', protect, getAllSalesOrders);
  *       - in: path
  *         name: id
  *         schema:
- *           type: integer
+ *           type: string
  *         required: true
- *         description: The sales order ID
+ *         description: The sales order ID (UUID)
  *     responses:
  *       200:
  *         description: The sales order description by ID
@@ -185,9 +185,9 @@ router.post('/bulk', protect, createMultipleSalesOrders);
  *       - in: path
  *         name: id
  *         schema:
- *           type: integer
+ *           type: string
  *         required: true
- *         description: The sales order ID
+ *         description: The sales order ID (UUID)
  *     requestBody:
  *       required: true
  *       content:
@@ -216,9 +216,9 @@ router.put('/:id', protect, updateSalesOrder);
  *       - in: path
  *         name: id
  *         schema:
- *           type: integer
+ *           type: string
  *         required: true
- *         description: The sales order ID
+ *         description: The sales order ID (UUID)
  *     responses:
  *       200:
  *         description: The sales order was deleted

--- a/src/services/salesOrderService.js
+++ b/src/services/salesOrderService.js
@@ -1,72 +1,74 @@
+import { v4 as uuidv4 } from 'uuid';
 import redisClient from '../config/redisClient.js';
 
-const SALES_ORDER_KEY_PREFIX = 'sales_order:';
-const ALL_SALES_ORDERS_KEY = 'sales_orders:all';
+const getSalesOrderKey = (userId) => `s:user:${userId}:salesorders`;
 
-export const getAllSalesOrders = async () => {
-    const salesOrderIds = await redisClient.smembers(ALL_SALES_ORDERS_KEY);
-    if (!salesOrderIds || salesOrderIds.length === 0) {
+export const getAllSalesOrders = async (userId) => {
+    const salesOrders = await redisClient.hgetall(getSalesOrderKey(userId));
+    // hgetall returns an object. If the key doesn't exist, it's an empty object.
+    if (!salesOrders || Object.keys(salesOrders).length === 0) {
         return [];
     }
-    const salesOrderKeys = salesOrderIds.map(id => `${SALES_ORDER_KEY_PREFIX}${id}`);
-    const salesOrders = await redisClient.mget(salesOrderKeys);
-    return salesOrders.map(order => JSON.parse(order));
+    return Object.values(salesOrders).map(order => JSON.parse(order));
 };
 
-export const getSalesOrderById = async (id) => {
-    const salesOrder = await redisClient.get(`${SALES_ORDER_KEY_PREFIX}${id}`);
+export const getSalesOrderById = async (userId, salesOrderId) => {
+    const salesOrder = await redisClient.hget(getSalesOrderKey(userId), salesOrderId);
     return salesOrder ? JSON.parse(salesOrder) : null;
 };
 
-export const createSalesOrder = async (orderData) => {
-    const newId = await redisClient.incr('sales_order:id_counter');
-    const newOrder = { ...orderData, id: newId };
+export const createSalesOrder = async (userId, orderData) => {
+    // Ignore any incoming salesorderid, and always generate a new one.
+    const { id, ...order } = orderData;
+    const salesOrderId = uuidv4();
+    const newOrder = { ...order, id: salesOrderId };
 
-    const pipeline = redisClient.pipeline();
-    pipeline.set(`${SALES_ORDER_KEY_PREFIX}${newOrder.id}`, JSON.stringify(newOrder));
-    pipeline.sadd(ALL_SALES_ORDERS_KEY, newOrder.id);
-    await pipeline.exec();
+    await redisClient.hset(
+        getSalesOrderKey(userId),
+        salesOrderId,
+        JSON.stringify(newOrder)
+    );
 
     return newOrder;
 };
 
-export const createMultipleSalesOrders = async (ordersData) => {
+export const createMultipleSalesOrders = async (userId, ordersData) => {
     const pipeline = redisClient.pipeline();
     const newOrders = [];
 
     for (const orderData of ordersData) {
-        const newId = await redisClient.incr('sales_order:id_counter');
-        const newOrder = { ...orderData, id: newId };
+        const { id, ...order } = orderData;
+        const salesOrderId = uuidv4();
+        const newOrder = { ...order, id: salesOrderId };
         newOrders.push(newOrder);
 
-        pipeline.set(`${SALES_ORDER_KEY_PREFIX}${newOrder.id}`, JSON.stringify(newOrder));
-        pipeline.sadd(ALL_SALES_ORDERS_KEY, newOrder.id);
+        pipeline.hset(
+            getSalesOrderKey(userId),
+            salesOrderId,
+            JSON.stringify(newOrder)
+        );
     }
 
     await pipeline.exec();
     return newOrders;
 };
 
-export const updateSalesOrder = async (id, updates) => {
-    const key = `${SALES_ORDER_KEY_PREFIX}${id}`;
-    const existingOrderJSON = await redisClient.get(key);
+export const updateSalesOrder = async (userId, salesOrderId, updates) => {
+    const key = getSalesOrderKey(userId);
+    const existingOrderJSON = await redisClient.hget(key, salesOrderId);
 
     if (!existingOrderJSON) {
         return null;
     }
 
     const existingOrder = JSON.parse(existingOrderJSON);
-    const updatedOrder = { ...existingOrder, ...updates };
+    const updatedOrder = { ...existingOrder, ...updates, id: salesOrderId };
 
-    await redisClient.set(key, JSON.stringify(updatedOrder));
+    await redisClient.hset(key, salesOrderId, JSON.stringify(updatedOrder));
     return updatedOrder;
 };
 
-export const deleteSalesOrder = async (id) => {
-    const key = `${SALES_ORDER_KEY_PREFIX}${id}`;
-    const pipeline = redisClient.pipeline();
-    pipeline.del(key);
-    pipeline.srem(ALL_SALES_ORDERS_KEY, id);
-    const results = await pipeline.exec();
-    return results[0][1]; // Result of the first del command
+export const deleteSalesOrder = async (userId, salesOrderId) => {
+    const key = getSalesOrderKey(userId);
+    return await redisClient.hdel(key, salesOrderId);
 };


### PR DESCRIPTION
This commit refactors the sales order storage mechanism to use Redis hashes, following the key pattern `s:user:<userid>:salesorders`.

Key changes include:
- The `salesOrderService` is updated to use `HSET`, `HGETALL`, `HGET`, and `HDEL` for CRUD operations on sales orders.
- Sales order IDs are now generated using UUIDv4, ensuring uniqueness and ignoring any client-sent ID.
- The `salesOrderController` now passes the authenticated user's ID to the service layer.
- Swagger documentation for sales order routes has been updated to reflect that the `id` is a string (UUID).