### PR TITLE
feat: Add timeseries API for shoe inventory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@influxdata/influxdb-client": "^1.35.0",
+        "@influxdata/influxdb-client-apis": "^1.35.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
@@ -613,6 +615,21 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@influxdata/influxdb-client": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.35.0.tgz",
+      "integrity": "sha512-woWMi8PDpPQpvTsRaUw4Ig+nOGS/CWwAwS66Fa1Vr/EkW+NEwxI8YfPBsdBMn33jK2Y86/qMiiuX/ROHIkJLTw==",
+      "license": "MIT"
+    },
+    "node_modules/@influxdata/influxdb-client-apis": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client-apis/-/influxdb-client-apis-1.35.0.tgz",
+      "integrity": "sha512-+7h6smVPHYBge2rNKgYh/5k+SriYvPMsoJDfbUiQt1vJtpWnElwgBDLDl7Cr6d9XPC+FCI9GP4GQEMv7y8WxdA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@influxdata/influxdb-client": "*"
       }
     },
     "node_modules/@ioredis/as-callback": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@influxdata/influxdb-client": "^1.35.0",
+    "@influxdata/influxdb-client-apis": "^1.35.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",

--- a/server.log
+++ b/server.log
@@ -1,0 +1,605 @@
+[2025-08-21T18:03:32.430Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-21T18:03:32.620Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-21T18:03:32.755Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.773Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.783Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.791Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.804Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.811Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.824Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.834Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.847Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:03:32.853Z] Request: DELETE /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: INVALID - secret or public key must be provided
+[2025-08-21T18:05:05.919Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-21T18:05:06.107Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-21T18:05:06.232Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.487Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.498Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.638Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.707Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.760Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.839Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.899Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:06.966Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:07.025Z] Request: DELETE /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"b3e74806-06f1-472c-a8e4-5b350fc9b5d0","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799506,"exp":1755803106}
+[2025-08-21T18:05:36.769Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-21T18:05:36.947Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-21T18:05:37.074Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.261Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.274Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.331Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.398Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.450Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.513Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.569Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.640Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-21T18:05:37.695Z] Request: DELETE /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"dbe44dad-aad4-4d67-aecb-d0ee8c751295","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755799537,"exp":1755803137}
+[2025-08-22T07:05:57.643Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:05:57.824Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:05:57.950Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.226Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.238Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.297Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.375Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.433Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.499Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.555Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.615Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.674Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:05:58.732Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"cdbd9b20-c83a-4c02-830b-8ce159bd4b02","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846357,"exp":1755849957}
+[2025-08-22T07:06:22.038Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:06:22.215Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:06:22.341Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.535Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.547Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.598Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.760Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.815Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.885Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:22.944Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:23.019Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:23.077Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:06:23.139Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"a7c0dfa4-cf27-4b07-b6b9-8d8e8a5955f2","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846382,"exp":1755849982}
+[2025-08-22T07:09:00.405Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:09:00.604Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:09:00.749Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:00.962Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:00.974Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.055Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.133Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.192Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.264Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.323Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.390Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.447Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:01.503Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"bda9ccc7-3bea-45bb-a25a-df79691b21f8","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846540,"exp":1755850140}
+[2025-08-22T07:09:42.309Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:09:42.465Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:09:42.592Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:42.793Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:42.805Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:42.858Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:42.926Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:42.979Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:43.042Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:43.097Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:43.160Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:43.210Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:09:43.268Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b4958bc7-e4dd-464d-8b6b-043252ced975","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846582,"exp":1755850182}
+[2025-08-22T07:12:25.449Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:12:25.608Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:12:25.732Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:25.861Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:25.870Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:25.926Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:25.992Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:26.060Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:26.123Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:26.180Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:26.241Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:26.296Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:12:26.352Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"86b092a2-c1e8-41c6-9dc0-1514e03d6bca","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846745,"exp":1755850345}
+[2025-08-22T07:14:40.815Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:14:41.007Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:14:41.140Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.277Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.290Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.348Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.430Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.490Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.562Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.621Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.690Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.748Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:14:41.803Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"7d514bf2-55be-4a49-b404-48bd6dabb1b3","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846881,"exp":1755850481}
+[2025-08-22T07:16:20.174Z] Request: POST /auth/register
+  Query: {}
+  Body: {"name":"Timeseries Test User","email":"timeseries-test@example.com","password":"password123","role":"Admin"}
+  Token: NOT PROVIDED
+[2025-08-22T07:16:20.368Z] Request: POST /auth/login
+  Query: {}
+  Body: {"email":"timeseries-test@example.com","password":"password123"}
+  Token: NOT PROVIDED
+[2025-08-22T07:16:20.525Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10","color":"blue","quantity":100}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:20.668Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"10"}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:20.684Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"9","color":"red","quantity":50}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:21.751Z] Request: GET /timeseries/shoes
+  Query: {}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:21.837Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"11","color":"green","quantity":20}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:21.901Z] Request: GET /timeseries/shoes?size=11
+  Query: {"size":"11"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:21.982Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"12","color":"black","quantity":30}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:22.046Z] Request: GET /timeseries/shoes?color=black
+  Query: {"color":"black"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:22.118Z] Request: POST /timeseries/shoes
+  Query: {}
+  Body: {"size":"8","color":"white","quantity":10}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:22.178Z] Request: POST /timeseries/shoes/sell
+  Query: {}
+  Body: {"size":"8","color":"white"}
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}
+[2025-08-22T07:16:22.240Z] Request: GET /timeseries/shoes?size=8&color=white
+  Query: {"size":"8","color":"white"}
+  Body: undefined
+  Token: VALID
+  User: {"id":"b6b294f7-693f-4108-882c-1a01306e6c4c","name":"Timeseries Test User","email":"timeseries-test@example.com","role":"Admin","iat":1755846980,"exp":1755850580}

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ import reviewRoutes from './routes/reviewRoutes.js';
 import customerRoutes from './routes/customerRoutes.js';
 import salesOrderRoutes from './routes/salesOrderRoutes.js';
 import invoiceRoutes from './routes/invoiceRoutes.js';
+import timeseriesRoutes from './routes/timeseriesRoutes.js';
 import loggingMiddleware from './middleware/loggingMiddleware.js';
 import errorLoggingMiddleware from './middleware/errorLoggingMiddleware.js';
 
@@ -44,6 +45,7 @@ app.use('/reviews', reviewRoutes);
 app.use('/customers', customerRoutes);
 app.use('/salesOrders', salesOrderRoutes);
 app.use('/invoices', invoiceRoutes);
+app.use('/timeseries', timeseriesRoutes);
 
 app.use(errorLoggingMiddleware);
 

--- a/src/config/influxdbClient.js
+++ b/src/config/influxdbClient.js
@@ -1,0 +1,9 @@
+import { InfluxDB } from '@influxdata/influxdb-client';
+import 'dotenv/config';
+
+const url = process.env.INFLUXDB_URL;
+const token = process.env.INFLUXDB_TOKEN;
+
+const influxDB = new InfluxDB({ url, token });
+
+export default influxDB;

--- a/src/controllers/timeseriesController.js
+++ b/src/controllers/timeseriesController.js
@@ -1,0 +1,37 @@
+import * as timeseriesService from '../services/timeseriesService.js';
+
+export const addShoe = async (req, res) => {
+  try {
+    const { size, color, quantity } = req.body;
+    if (!size || !color || !quantity) {
+      return res.status(400).json({ message: 'Missing required fields: size, color, quantity' });
+    }
+    await timeseriesService.addShoe(size, color, quantity);
+    res.status(201).json({ message: 'Shoe data added successfully' });
+  } catch (error) {
+    res.status(500).json({ message: 'Error adding shoe data', error: error.message });
+  }
+};
+
+export const getShoes = async (req, res) => {
+  try {
+    const filters = req.query;
+    const shoes = await timeseriesService.getShoes(filters);
+    res.status(200).json(shoes);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving shoe data', error: error.message });
+  }
+};
+
+export const sellShoe = async (req, res) => {
+    try {
+        const { size, color } = req.body;
+        if (!size || !color) {
+            return res.status(400).json({ message: 'Missing required fields: size, color' });
+        }
+        await timeseriesService.sellShoe(size, color);
+        res.status(200).json({ message: 'Shoe sold successfully' });
+    } catch (error) {
+        res.status(500).json({ message: 'Error selling shoe', error: error.message });
+    }
+};

--- a/src/routes/timeseriesRoutes.js
+++ b/src/routes/timeseriesRoutes.js
@@ -1,0 +1,105 @@
+import { Router } from 'express';
+import {
+  addShoe,
+  getShoes,
+  sellShoe,
+} from '../controllers/timeseriesController.js';
+import { protect } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Timeseries
+ *   description: The timeseries managing API for shoes
+ */
+
+/**
+ * @swagger
+ * /timeseries/shoes:
+ *   post:
+ *     summary: Add a new shoe to the timeseries data
+ *     tags: [Timeseries]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               size:
+ *                 type: string
+ *               color:
+ *                 type: string
+ *               quantity:
+ *                 type: integer
+ *     responses:
+ *       201:
+ *         description: The shoe data was successfully added
+ *       400:
+ *         description: Missing required fields
+ *       500:
+ *         description: Some server error
+ */
+router.post('/shoes', protect, addShoe);
+
+/**
+ * @swagger
+ * /timeseries/shoes:
+ *   get:
+ *     summary: Get shoe data from the timeseries
+ *     tags: [Timeseries]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: size
+ *         schema:
+ *           type: string
+ *         description: The size of the shoe to filter by
+ *       - in: query
+ *         name: color
+ *         schema:
+ *           type: string
+ *         description: The color of the shoe to filter by
+ *     responses:
+ *       200:
+ *         description: A list of shoe data
+ *       500:
+ *         description: Some server error
+ */
+router.get('/shoes', protect, getShoes);
+
+/**
+ * @swagger
+ * /timeseries/shoes/sell:
+ *   post:
+ *     summary: Mark a shoe as sold in the timeseries data
+ *     tags: [Timeseries]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               size:
+ *                 type: string
+ *               color:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: The shoe was successfully marked as sold
+ *       400:
+ *         description: Missing required fields
+ *       500:
+ *         description: Some server error
+ */
+router.post('/shoes/sell', protect, sellShoe);
+
+export default router;

--- a/src/services/timeseriesService.js
+++ b/src/services/timeseriesService.js
@@ -1,0 +1,69 @@
+import { InfluxDB, Point } from '@influxdata/influxdb-client';
+import 'dotenv/config';
+import influxDB from '../config/influxdbClient.js';
+
+const org = process.env.INFLUXDB_ORG;
+const bucket = process.env.INFLUXDB_BUCKET;
+
+const writeApi = influxDB.getWriteApi(org, bucket);
+const queryApi = influxDB.getQueryApi(org);
+
+export const addShoe = async (size, color, quantity) => {
+  const point = new Point('shoes')
+    .tag('size', size)
+    .tag('color', color)
+    .intField('quantity', quantity)
+    .timestamp(new Date());
+
+  writeApi.writePoint(point);
+  await writeApi.flush();
+};
+
+export const getShoes = async (filters) => {
+  let fluxQuery = `from(bucket: "${bucket}")
+    |> range(start: -30d)
+    |> filter(fn: (r) => r._measurement == "shoes")`;
+
+  if (filters.size) {
+    fluxQuery += ` |> filter(fn: (r) => r.size == "${filters.size}")`;
+  }
+
+  if (filters.color) {
+    fluxQuery += ` |> filter(fn: (r) => r.color == "${filters.color}")`;
+  }
+
+  fluxQuery += `
+    |> last()
+    |> filter(fn: (r) => r._value > 0)`;
+
+  const results = [];
+  return new Promise((resolve, reject) => {
+    queryApi.queryRows(fluxQuery, {
+      next(row, tableMeta) {
+        const o = tableMeta.toObject(row);
+        results.push(o);
+      },
+      error(error) {
+        reject(error);
+      },
+      complete() {
+        resolve(results);
+      },
+    });
+  });
+};
+
+export const sellShoe = async (size, color) => {
+    const point = new Point('shoes')
+        .tag('size', size)
+        .tag('color', color)
+        .intField('quantity', 0)
+        .timestamp(new Date());
+
+    writeApi.writePoint(point);
+    await writeApi.flush();
+};
+
+export const close = async () => {
+    await writeApi.close();
+};

--- a/test/timeseries.test.js
+++ b/test/timeseries.test.js
@@ -1,0 +1,171 @@
+import request from 'supertest';
+import app from '../src/app.js';
+import { expect } from '@jest/globals';
+import https from 'https';
+import * as timeseriesService from '../src/services/timeseriesService.js';
+
+const createBucket = () => {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify({
+      orgID: process.env.INFLUXDB_ORG,
+      name: process.env.INFLUXDB_BUCKET,
+      retentionRules: [{ type: 'expire', everySeconds: 86400 * 30 }], // 30 days
+    });
+
+    const options = {
+      hostname: new URL(process.env.INFLUXDB_URL).hostname,
+      port: 443,
+      path: '/api/v2/buckets',
+      method: 'POST',
+      headers: {
+        'Authorization': `Token ${process.env.INFLUXDB_TOKEN}`,
+        'Content-Type': 'application/json',
+        'Content-Length': data.length,
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      // Buckets API returns 201 on success, 422 if bucket already exists.
+      // Both are acceptable for our test setup.
+      if (res.statusCode === 201 || res.statusCode === 422) {
+        resolve();
+      } else {
+        let responseBody = '';
+        res.on('data', (chunk) => {
+            responseBody += chunk;
+        });
+        res.on('end', () => {
+            console.error('Error creating bucket:', responseBody);
+            reject(new Error(`Failed to create bucket: ${res.statusCode}`));
+        });
+      }
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+
+    req.write(data);
+    req.end();
+  });
+};
+
+
+describe('Timeseries API', () => {
+  let token;
+
+  beforeAll(async () => {
+    await createBucket();
+    // Register and login a user to get a token
+    const email = `timeseries-test@example.com`;
+    const password = 'password123';
+    await request(app)
+      .post('/auth/register')
+      .send({
+        name: 'Timeseries Test User',
+        email,
+        password,
+        role: 'Admin',
+      });
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({
+        email,
+        password,
+      });
+    token = loginRes.body.token;
+  });
+
+  afterAll(async () => {
+    await timeseriesService.close();
+  });
+
+  it('should add a shoe to the timeseries data', async () => {
+    const res = await request(app)
+      .post('/timeseries/shoes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ size: '10', color: 'blue', quantity: 100 });
+    expect(res.statusCode).toEqual(201);
+    expect(res.body).toHaveProperty('message', 'Shoe data added successfully');
+  });
+
+  it('should not add a shoe if required fields are missing', async () => {
+    const res = await request(app)
+        .post('/timeseries/shoes')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ size: '10' });
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toHaveProperty('message', 'Missing required fields: size, color, quantity');
+  });
+
+  it('should get all available shoes', async () => {
+    await request(app)
+      .post('/timeseries/shoes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ size: '9', color: 'red', quantity: 50 });
+
+    const res = await request(app)
+      .get('/timeseries/shoes')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toEqual(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    const redShoes = res.body.filter(shoe => shoe.color === 'red');
+    expect(redShoes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should get shoes filtered by size', async () => {
+    await request(app)
+      .post('/timeseries/shoes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ size: '11', color: 'green', quantity: 20 });
+
+    const res = await request(app)
+      .get('/timeseries/shoes?size=11')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toEqual(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].size).toBe('11');
+  });
+
+  it('should get shoes filtered by color', async () => {
+    await request(app)
+      .post('/timeseries/shoes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ size: '12', color: 'black', quantity: 30 });
+
+    const res = await request(app)
+      .get('/timeseries/shoes?color=black')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toEqual(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].color).toBe('black');
+  });
+
+  it('should sell a shoe and it should not appear in get requests', async () => {
+    // Add a shoe
+    await request(app)
+      .post('/timeseries/shoes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ size: '8', color: 'white', quantity: 10 });
+
+    // Sell the shoe
+    const res = await request(app)
+      .post('/timeseries/shoes/sell')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ size: '8', color: 'white' });
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toHaveProperty('message', 'Shoe sold successfully');
+
+    // Verify it's not returned in get requests
+    const getRes = await request(app)
+        .get('/timeseries/shoes?size=8&color=white')
+        .set('Authorization', `Bearer ${token}`);
+    expect(getRes.statusCode).toEqual(200);
+    expect(getRes.body.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This commit introduces a new API for managing shoe inventory using a timeseries database (InfluxDB).

The API provides the following functionality:
- `POST /timeseries/shoes`: Add a new shoe to the inventory.
- `GET /timeseries/shoes`: Get a list of all available shoes. Supports filtering by size and color.
- `POST /timeseries/shoes/sell`: Mark a shoe as sold by setting its quantity to 0.

The implementation includes:
- A new `timeseriesService` to handle the business logic for interacting with InfluxDB.
- A new `timeseriesController` to handle the HTTP requests.
- New routes in `timeseriesRoutes.js` with Swagger documentation.
- Tests for the new API in `test/timeseries.test.js`.

Known Issues:
- The tests for querying data (`GET /timeseries/shoes`) are currently failing. They are returning an empty array, even though data is being written successfully. This seems to be an issue with how the data is being written to or queried from InfluxDB. Further investigation is required to resolve this issue.